### PR TITLE
#12 Conseguir melhor fluidez nas leituras

### DIFF
--- a/Firmware/Solution BLE/Solution/main.c
+++ b/Firmware/Solution BLE/Solution/main.c
@@ -14,7 +14,6 @@ int main(void)
 	initializeSystem();
 	while (1)
 	{
-		processBLEMessages();
-		_delay_ms(10);
+		
 	}
 }

--- a/Firmware/Solution BLE/Solution/software_uart_ble.c
+++ b/Firmware/Solution BLE/Solution/software_uart_ble.c
@@ -42,7 +42,7 @@ void atomicBlockBleEnd(unsigned char currentState) {
 	}
 }
 
-void receiveBleByte() {
+unsigned char receiveBleByte() {
 	unsigned char i, readChar=0;
 	if (!(PIND & (1<<PORTD7))) {
 		OCR1A = 576;
@@ -63,12 +63,14 @@ void receiveBleByte() {
 		bleInBufferEndIndex = (bleInBufferEndIndex + 1)%BLE_BUFFER_SIZE;
 		if (bleInBufferEndIndex == bleInBufferStartIndex) bleInBufferStartIndex = (bleInBufferStartIndex + 1)%BLE_BUFFER_SIZE;
 	}
+	return readChar;
 }
 
 ISR(PCINT2_vect) {
 	unsigned char interruptState;
 	interruptState = atomicBlockBleBegin();
-	receiveBleByte();
+	unsigned char c = receiveBleByte();
+	if (c == ';') processBLEMessages();
 	atomicBlockBleEnd(interruptState);
 }
 

--- a/Firmware/Solution BLE/Solution/software_uart_ble.h
+++ b/Firmware/Solution BLE/Solution/software_uart_ble.h
@@ -14,7 +14,7 @@
 unsigned char atomicBlockBleBegin();
 void atomicBlockBleEnd(unsigned char currentState);
 
-void receiveBleByte();
+unsigned char receiveBleByte();
 void resetBleBuffer();
 
 void bleSendByte(unsigned char c);


### PR DESCRIPTION
Processamento de buffer BLE só ocorre quando é recebido caractere separador de comando